### PR TITLE
수정: 네이버 이미지 검색 https

### DIFF
--- a/tcat/views.py
+++ b/tcat/views.py
@@ -325,6 +325,8 @@ def naver_image_search(request):
     response = requests.get("https://openapi.naver.com/v1/search/image", headers=headers, params=params)
     result = response.json()
 
+    result['items'] = [item for item in result['items'] if item['link'].startswith('https://')]
+
     return JsonResponse(result)
 
 


### PR DESCRIPTION
- 네이버 웹 이미지 검색 https로만 시작하는 url 이미지만 검색하게 수정